### PR TITLE
Launch language server with environment from .env file (fixes #60)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -151,6 +151,15 @@
       "integrity": "sha512-GpKm6eL8EhNtlDdNDM/r8dAz8kdoYWjU4GFZGc4NARYNJgsoBjaVSo5tDAUebTr/uDioWULKpk44KgmFyFBlPw==",
       "dev": true
     },
+    "@types/dotenv": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-6.1.0.tgz",
+      "integrity": "sha512-gmbNb7V1LbJQA4MmH0hVFgqY1cyKsa6RvKC1Xrq0WBnZ0JuuvXKciXx/s8dN0LVXCJd8xO6wIaSFSyUIoGph9g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/events": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
@@ -830,9 +839,9 @@
       }
     },
     "dotenv": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
-      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+      "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
     },
     "duplexer": {
       "version": "0.1.1",
@@ -2474,6 +2483,13 @@
         "replaceall": "^0.1.6",
         "scuid": "^1.0.2",
         "yaml-ast-parser": "^0.0.40"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+          "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
+        }
       }
     },
     "process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
   },
   "devDependencies": {
     "@types/capitalize": "^1.0.1",
+    "@types/dotenv": "^6.1.0",
     "@types/graphql": "0.13.2",
     "@types/mocha": "^2.2.42",
     "@types/node": "^7.0.43",
@@ -144,6 +145,7 @@
     "apollo-link-ws": "^1.0.8",
     "babel-polyfill": "^6.26.0",
     "capitalize": "^1.0.0",
+    "dotenv": "^6.2.0",
     "graphql": "0.13.2",
     "graphql-config": "^2.1.0",
     "graphql-config-extension-prisma": "0.2.1",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,7 +46,7 @@ function getEnvironment() {
     }
   });
 
-  return { ...process.env, ...workspaceEnv };
+  return { ...workspaceEnv, ...process.env };
 }
 
 export async function activate(context: ExtensionContext) {
@@ -155,7 +155,7 @@ export async function activate(context: ExtensionContext) {
           "GraphQL Content Provider"
         )
         .then(
-          _ => {},
+          _ => { },
           _ => {
             window.showErrorMessage("Error opening content.");
           }


### PR DESCRIPTION
This mostly fixes https://github.com/prisma/vscode-graphql/issues/60 by launching the GraphQL Language Server with variables from `.env` added to its environment.

The bigger issue however is that there is no visible error when the language server fails to parse the config file (e.g. when an environment variable doesn't exist at all, or for any other reason).