### PR TITLE
Add support for autocomplete from javascript files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,9 +86,12 @@ export async function activate(context: ExtensionContext) {
   };
 
   let clientOptions: LanguageClientOptions = {
-    documentSelector: [{ scheme: "file", language: "graphql" }],
+    documentSelector: [
+      { scheme: "file", language: "graphql" }
+      { scheme: "file", language: "javascript" },
+    ],
     synchronize: {
-      fileEvents: workspace.createFileSystemWatcher("**/*.{graphql,gql}")
+      fileEvents: workspace.createFileSystemWatcher("**/*.{graphql,gql,js}")
     },
     outputChannel: outputChannel,
     outputChannelName: "GraphQL Language Server",

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,5 +1,5 @@
-import { startServer } from "graphql-language-service-server";
 import "babel-polyfill";
+import { startServer } from "graphql-language-service-server";
 import { patchConfig } from "graphql-config-extension-prisma";
 
 (async () => {


### PR DESCRIPTION
This enables the graphql language server extension when in javascript files which will enable autocomplete when using tagged templates. This combined with https://github.com/graphql/graphiql/pull/883 will fix autocomplete with the gql tagged template.

Fixes #61 
Fixes #21 
Fixes #53 
Fixes #96 