### PR TITLE
fix(graphql-content-provider.ts): language server fails silently when…

### DIFF
--- a/src/client/graphql-content-provider.ts
+++ b/src/client/graphql-content-provider.ts
@@ -20,6 +20,10 @@ import { visit, VariableDefinitionNode } from "graphql";
 import { NetworkHelper } from "./network-helper";
 import { SourceHelper, GraphQLScalarTSType } from "./source-helper";
 
+type Env = {
+  [name: string]: string | undefined;
+};
+
 // TODO: remove residue of previewHtml API https://github.com/microsoft/vscode/issues/62630
 // We update the panel directly now in place of a event based update API (we might make a custom event updater and remove panel dep though)
 export class GraphQLContentProvider implements TextDocumentContentProvider {
@@ -28,6 +32,7 @@ export class GraphQLContentProvider implements TextDocumentContentProvider {
   private networkHelper: NetworkHelper;
   private sourceHelper: SourceHelper;
   private panel: WebviewPanel;
+  private env: Env;
 
   // Event emitter which invokes document updates
   private _onDidChange = new EventEmitter<Uri>();
@@ -105,13 +110,15 @@ export class GraphQLContentProvider implements TextDocumentContentProvider {
     uri: Uri,
     outputChannel: OutputChannel,
     literal: ExtractedTemplateLiteral,
-    panel: WebviewPanel
+    panel: WebviewPanel,
+    env: Env
   ) {
     this.uri = uri;
     this.outputChannel = outputChannel;
     this.networkHelper = new NetworkHelper(this.outputChannel);
     this.sourceHelper = new SourceHelper(this.outputChannel);
     this.panel = panel;
+    this.env = env;
 
     try {
       const rootDir = workspace.getWorkspaceFolder(Uri.file(literal.uri));
@@ -159,7 +166,8 @@ export class GraphQLContentProvider implements TextDocumentContentProvider {
 
         this.getEndpointName(endpointNames).then(endpointName => {
           const endpoint = projectConfig!.endpointsExtension!.getEndpoint(
-            endpointName
+            endpointName,
+            this.env
           );
 
           let variableDefinitionNodes: VariableDefinitionNode[] = [];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -154,7 +154,8 @@ export async function activate(context: ExtensionContext) {
         uri,
         outputChannel,
         literal,
-        panel
+        panel,
+        combinedEnv
       );
       const registration = workspace.registerTextDocumentContentProvider(
         "graphql",


### PR DESCRIPTION
… getting endpoint if it contains env variable.

This fix is related to #98 and deals with one of the reasons referred to as **any other reason**:

> The bigger issue however is that there is no visible error when the language server fails to parse the config file (e.g. when an environment variable doesn't exist at all, or for any other reason). 

The language server in the following case will fails silently. Given a `.graphqlconfig` file containing the following `endpoints`:

```
{
  "endpoints": {
    "default": {
      "url": "https://www.someurl.com",
      "headers": {
        "Authorization": "Bearer ${env:AUTH_TOKEN}"
      }
    }
  }
}
```

then when executing a query using the extension, it will result in an empty content. However, if you debug the extension, a `Environment variable AUTH_TOKEN is not set` error will be logged.